### PR TITLE
Add password hash assertion to register test

### DIFF
--- a/test_users.py
+++ b/test_users.py
@@ -2,7 +2,7 @@
 import pytest
 import json
 from main import app, db, User
-from werkzeug.security import generate_password_hash
+from werkzeug.security import generate_password_hash, check_password_hash
 
 @pytest.fixture
 def client():
@@ -56,6 +56,8 @@ class TestUserRegistration:
         assert user is not None
         assert user.email == sample_user['email']
         assert user.role == 'user'
+        assert user.password != sample_user['password']
+        assert check_password_hash(user.password, sample_user['password'])
     
     def test_register_missing_email(self, client):
         """Test registration with missing email."""


### PR DESCRIPTION
## Summary
- ensure stored password is hashed in `test_register_success`

## Testing
- `pytest test_users.py::TestUserRegistration::test_register_success -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683fa9bff5dc832e9fa1d7e6bba5f769