### PR TITLE
Add event search feature

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,6 +1,7 @@
 
 from flask import Blueprint, render_template, request, jsonify, session, flash, redirect, url_for, current_app
 from app.models import Event, RSVP, Company, User, Reward
+from sqlalchemy import or_
 from app.auth.decorators import decode_token
 from app.extensions import db
 import datetime
@@ -33,6 +34,18 @@ def db_health():
 def show_events():
     events = Event.query.order_by(Event.date).all()
     return render_template('events.html', events=events)
+
+@main_bp.route('/search')
+def search():
+    """Search events by title or description."""
+    q = request.args.get('q', '').strip()
+    events = []
+    if q:
+        pattern = f"%{q}%"
+        events = Event.query.filter(
+            or_(Event.name.ilike(pattern), Event.description.ilike(pattern))
+        ).all()
+    return render_template('search_results.html', query=q, events=events)
 
 @main_bp.route('/testing-opportunities')
 def testing_opportunities():

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,12 @@
 {% block title %}Welcome - Tech Access Group{% endblock %}
 
 {% block content %}
+<form class="container mb-4" method="get" action="{{ url_for('main.search') }}">
+  <div class="input-group">
+    <input type="text" class="form-control" name="q" placeholder="Search events...">
+    <button class="btn btn-primary" type="submit">Search</button>
+  </div>
+</form>
 <!-- Hero Section -->
 <div class="hero-section text-center py-5 mb-5">
   <div class="container">

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Search Results{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2 class="mb-4">Search results for '{{ query }}'</h2>
+  {% if events %}
+    <ul class="list-group">
+    {% for ev in events %}
+      <li class="list-group-item">
+        <a href="{{ url_for('main.show_event', event_id=ev.id) }}">{{ ev.title or ev.name }}</a>
+        <p class="mb-0 text-muted">{{ ev.description[:150] }}{% if ev.description|length > 150 %}...{% endif %}</p>
+      </li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p>No events found matching '{{ query }}'.</p>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add simple search form on home page
- implement `/search` route in main blueprint
- create `search_results.html` for showing results

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684302019e34832ea205f94364b9a4a6