### PR TITLE
Add event search with tests

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -40,12 +40,13 @@ def show_events():
 def search():
     """Search events by title or description."""
     q = request.args.get('q', '').strip()
-    events = []
     if q:
         pattern = f"%{q}%"
         events = Event.query.filter(
-            or_(Event.name.ilike(pattern), Event.description.ilike(pattern))
-        ).all()
+            or_(Event.title.ilike(pattern), Event.description.ilike(pattern))
+        ).order_by(Event.date).all()
+    else:
+        events = []
     return render_template('search_results.html', query=q, events=events)
 
 @main_bp.route('/testing-opportunities')

--- a/app/models.py
+++ b/app/models.py
@@ -109,12 +109,21 @@ class Company(db.Model):
 class Event(db.Model):
     __tablename__ = "events"
     id = db.Column(db.String, primary_key=True, default=lambda: str(uuid.uuid4()))
-    name = db.Column(db.String(128), nullable=False)
+    title = db.Column(db.String(128), nullable=False)
     description = db.Column(db.Text, nullable=False)
     date = db.Column(db.DateTime, nullable=False)
     company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True)
     user_id = db.Column(db.String, db.ForeignKey("users.id"), nullable=True)  # For user-created events
     rsvps = db.relationship("RSVP", back_populates="event", cascade="all, delete-orphan")
+
+    # Backwards compatibility for code that still references ``name``
+    @property
+    def name(self):
+        return self.title
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self.title = value
 
 
 class RSVP(db.Model):

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,10 @@
 {% block title %}Welcome - Tech Access Group{% endblock %}
 
 {% block content %}
-<form class="container mb-4" method="get" action="{{ url_for('main.search') }}">
+<form action="{{ url_for('main.search') }}" method="get" class="mb-4">
   <div class="input-group">
-    <input type="text" class="form-control" name="q" placeholder="Search events...">
-    <button class="btn btn-primary" type="submit">Search</button>
+    <input type="text" name="q" class="form-control" placeholder="Search events…" required>
+    <button type="submit" class="btn btn-primary">Search</button>
   </div>
 </form>
 <!-- Hero Section -->

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,19 +1,22 @@
-{% extends "base.html" %}
-{% block title %}Search Results{% endblock %}
+{% extends 'base.html' %}
+
 {% block content %}
-<div class="container py-4">
-  <h2 class="mb-4">Search results for '{{ query }}'</h2>
+<div class="container">
+  <h2>Search results for “{{ query }}”</h2>
+
   {% if events %}
     <ul class="list-group">
-    {% for ev in events %}
-      <li class="list-group-item">
-        <a href="{{ url_for('main.show_event', event_id=ev.id) }}">{{ ev.title or ev.name }}</a>
-        <p class="mb-0 text-muted">{{ ev.description[:150] }}{% if ev.description|length > 150 %}...{% endif %}</p>
-      </li>
-    {% endfor %}
+      {% for ev in events %}
+        <li class="list-group-item">
+          <strong>{{ ev.title }}</strong> – {{ ev.date.strftime('%Y-%m-%d') }}
+          <p class="mb-0">
+            {{ ev.description[:100] }}{% if ev.description|length > 100 %}…{% endif %}
+          </p>
+        </li>
+      {% endfor %}
     </ul>
   {% else %}
-    <p>No events found matching '{{ query }}'.</p>
+    <p>No events found matching “{{ query }}.”</p>
   {% endif %}
 </div>
 {% endblock %}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,28 @@
+import pytest
+from app import create_app, db
+from app.models import Event
+from datetime import datetime
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        event = Event(title='Sample Event', description='This is a test.', date=datetime(2025, 7, 1))
+        db.session.add(event)
+        db.session.commit()
+    yield app.test_client()
+
+
+def test_search_finds_event(client):
+    res = client.get('/search?q=Sample')
+    assert res.status_code == 200
+    assert b'Sample Event' in res.data
+
+
+def test_search_no_results(client):
+    res = client.get('/search?q=NoMatch')
+    assert res.status_code == 200
+    assert b'No events found' in res.data


### PR DESCRIPTION
## Summary
- add search route in main blueprint using Event.title and description
- support legacy Event.name usage
- update search results template and homepage search form
- include tests for search functionality

## Testing
- `pytest tests/test_search.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430b3567dc832e9c6b16e8d10eb99c