### PR TITLE
Add company search feature

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -49,6 +49,20 @@ def search():
         events = []
     return render_template('search_results.html', query=q, events=events)
 
+
+@main_bp.route('/search/companies')
+def search_companies():
+    """Search companies by name or description."""
+    q = request.args.get('q', '').strip()
+    if q:
+        pattern = f"%{q}%"
+        companies = Company.query.filter(
+            or_(Company.name.ilike(pattern), Company.description.ilike(pattern))
+        ).order_by(Company.name).all()
+    else:
+        companies = []
+    return render_template('company_search_results.html', query=q, companies=companies)
+
 @main_bp.route('/testing-opportunities')
 def testing_opportunities():
     return render_template('testing_opportunities.html')
@@ -330,3 +344,10 @@ def fulfill_rsvp(rsvp_id):
     except Exception as e:
         db.session.rollback()
         return jsonify({'error': f'Failed to update RSVP: {str(e)}'}), 500
+
+
+@main_bp.route('/companies/<int:company_id>')
+def show_company(company_id):
+    """Display a company's details."""
+    company = Company.query.get_or_404(company_id)
+    return f"Company: {company.name}"

--- a/templates/company_search_results.html
+++ b/templates/company_search_results.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+
+{% block body %}
+<div class="container">
+  <h2>Company results for '{{ query }}'</h2>
+  {% if companies %}
+    <ul class="list-group">
+      {% for comp in companies %}
+        <li class="list-group-item">
+          <a href="{{ url_for('main.show_company', company_id=comp.id) }}">{{ comp.name }}</a>
+          <p class="mb-0">{{ comp.description[:100] }}{% if comp.description and comp.description|length > 100 %}…{% endif %}</p>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>No companies found matching '{{ query }}.'</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,12 @@
     <button type="submit" class="btn btn-primary">Search</button>
   </div>
 </form>
+<form action="{{ url_for('main.search_companies') }}" method="get" class="mb-4">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="Search companies…" required>
+    <button type="submit" class="btn btn-primary">Search Companies</button>
+  </div>
+</form>
 <!-- Hero Section -->
 <div class="hero-section text-center py-5 mb-5">
   <div class="container">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% block body %}{% endblock %}
+{% endblock %}

--- a/tests/test_company_search.py
+++ b/tests/test_company_search.py
@@ -1,0 +1,27 @@
+import pytest
+from app import create_app, db
+from app.models import Company
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        company = Company(name='TechCorp', contact_email='corp@example.com', password='secret', description='Leading tech solutions')
+        db.session.add(company)
+        db.session.commit()
+    yield app.test_client()
+
+
+def test_company_search_found(client):
+    res = client.get('/search/companies?q=TechCorp')
+    assert res.status_code == 200
+    assert b'TechCorp' in res.data
+
+
+def test_company_search_no_results(client):
+    res = client.get('/search/companies?q=NoMatch')
+    assert res.status_code == 200
+    assert b'No companies found' in res.data


### PR DESCRIPTION
## Summary
- search companies by name or description with `/search/companies`
- add linkable results template and layout wrapper
- allow searching companies from home page
- provide placeholder route to show a company's detail
- add tests for company search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843130aa250832e8a23d364b48c4597