### PR TITLE
Add Cancel RSVP functionality

### DIFF
--- a/app/users/forms.py
+++ b/app/users/forms.py
@@ -8,3 +8,8 @@ class ProfileForm(FlaskForm):
     bio = TextAreaField('Bio')
     avatar = FileField('Avatar', validators=[Optional(), FileAllowed(['jpg', 'png', 'jpeg'], 'Images only!')])
     submit = SubmitField('Save Profile')
+
+
+class CancelRSVPForm(FlaskForm):
+    """Empty form used solely for CSRF protection when cancelling an RSVP."""
+    submit = SubmitField('Cancel RSVP')

--- a/templates/my_rsvps.html
+++ b/templates/my_rsvps.html
@@ -8,8 +8,14 @@
     <ul class="list-group">
       {% for event in events %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
-          <a href="#" class="text-decoration-none">{{ event.title }}</a>
-          <small class="text-muted">{{ event.date.strftime('%B %d, %Y') }}</small>
+          <div>
+            <strong>{{ event.title }}</strong>
+            <small class="text-muted ms-2">{{ event.date.strftime('%B %d, %Y') }}</small>
+          </div>
+          <form method="post" action="{{ url_for('users.cancel_rsvp', event_id=event.id) }}" class="d-inline">
+            {{ form.csrf_token }}
+            <button type="submit" class="btn btn-sm btn-danger">Cancel RSVP</button>
+          </form>
         </li>
       {% endfor %}
     </ul>

--- a/tests/test_cancel_rsvp.py
+++ b/tests/test_cancel_rsvp.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from app import create_app, db
 from app.models import User, Event, RSVP
 
+
 @pytest.fixture
 def client(tmp_path):
     app = create_app()
@@ -17,28 +18,35 @@ def login(client, email, password):
     client.post('/login', data={'email': email, 'password': password})
 
 
-def test_my_rsvps_shows_event(client):
+def test_cancel_existing_rsvp(client):
     with client.application.app_context():
-        user = User(email='user1@example.com', password='pw')
-        event = Event(id='10', title='Test Event', description='Desc', date=datetime(2025,1,1))
+        user = User(email='cancel@example.com', password='pw')
+        event = Event(id='1', title='Delete Event', description='Desc', date=datetime(2030, 1, 1))
         db.session.add_all([user, event])
         db.session.commit()
         rsvp = RSVP(user_id=user.id, event_id=event.id)
         db.session.add(rsvp)
         db.session.commit()
-    login(client, 'user1@example.com', 'pw')
-    res = client.get('/my-rsvps')
-    assert res.status_code == 200
-    assert b'Test Event' in res.data
+        evt_id = event.id
 
-
-def test_my_rsvps_empty(client):
-    with client.application.app_context():
-        user = User(email='user2@example.com', password='pw')
-        db.session.add(user)
-        db.session.commit()
-    login(client, 'user2@example.com', 'pw')
+    login(client, 'cancel@example.com', 'pw')
     res = client.get('/my-rsvps')
+    assert b'Delete Event' in res.data
+
+    res = client.post(f'/cancel-rsvp/{evt_id}', follow_redirects=True)
     assert res.status_code == 200
     assert b"You haven\xe2\x80\x99t signed up for any events yet" in res.data
 
+
+def test_cancel_nonexistent_rsvp(client):
+    with client.application.app_context():
+        user = User(email='noevent@example.com', password='pw')
+        event = Event(id='2', title='Lonely Event', description='Desc', date=datetime(2031, 1, 1))
+        db.session.add_all([user, event])
+        db.session.commit()
+        evt_id = event.id
+
+    login(client, 'noevent@example.com', 'pw')
+    res = client.post(f'/cancel-rsvp/{evt_id}', follow_redirects=True)
+    assert res.status_code == 200
+    assert b"You haven\xe2\x80\x99t signed up for any events yet" in res.data


### PR DESCRIPTION
## Summary
- add `CancelRSVPForm`
- extend user blueprint with viewing and canceling RSVPs
- render cancel buttons in `my_rsvps.html`
- adapt tests for numeric ids and cover cancelling RSVPs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843502c6fc8832eb439faae03a9841f