### PR TITLE
Add attendee list on event detail page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -42,7 +42,10 @@ def event_detail(event_id):
     """Display a single event's details."""
     event = Event.query.get_or_404(event_id)
     count = event.rsvps.count()
-    return render_template('event_detail.html', event=event, count=count)
+    attendees = [rsvp.user for rsvp in event.rsvps.all()]
+    return render_template(
+        'event_detail.html', event=event, count=count, attendees=attendees
+    )
 
 @main_bp.route('/search')
 def search():

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -8,5 +8,17 @@
   <p>{{ event.description }}</p>
   <p>Date: {{ event.date }}</p>
   <p>RSVPs: {{ count }}</p>
+  <h3>Attendees</h3>
+  {% if attendees %}
+    <ul class="list-group">
+      {% for user in attendees %}
+        <li class="list-group-item">
+          {{ user.name or user.email }}
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>No one has RSVP’d yet.</p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/tests/test_event_attendees.py
+++ b/tests/test_event_attendees.py
@@ -1,0 +1,43 @@
+import pytest
+from datetime import datetime
+from app import create_app, db
+from app.models import Event, User, RSVP
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+    return app.test_client()
+
+
+def test_event_attendees_none(client):
+    with client.application.app_context():
+        event = Event(id='evtA', title='No RSVPs', description='Desc', date=datetime(2030, 1, 1))
+        db.session.add(event)
+        db.session.commit()
+        url = f'/events/{event.id}'
+    res = client.get(url)
+    assert res.status_code == 200
+    assert 'No one has RSVP\u2019d yet' in res.data.decode('utf-8')
+
+
+def test_event_attendees_two(client):
+    with client.application.app_context():
+        user1 = User(email='a@example.com', password='pw', name='Alice')
+        user2 = User(email='b@example.com', password='pw', name='Bob')
+        event = Event(id='evtB', title='With RSVPs', description='Desc', date=datetime(2030, 1, 1))
+        db.session.add_all([user1, user2, event])
+        db.session.commit()
+        r1 = RSVP(user_id=user1.id, event_id=event.id)
+        r2 = RSVP(user_id=user2.id, event_id=event.id)
+        db.session.add_all([r1, r2])
+        db.session.commit()
+        url = f'/events/{event.id}'
+    res = client.get(url)
+    assert res.status_code == 200
+    html = res.data.decode('utf-8')
+    assert 'Alice' in html
+    assert 'Bob' in html


### PR DESCRIPTION
## Summary
- fetch attendees in event detail route
- show list of attendees on the event detail template
- test attendee listing in new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684360c93fbc832e85e2030fe780f57f