### PR TITLE
Add Event Categories feature

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,6 +58,7 @@ def create_app():
     from app.users import users_bp
     from app.companies.routes import companies_bp
     from app.events.routes import evt_bp as events_bp
+    from app.categories import categories_bp
     from app.main.routes import main_bp
     from app.checks.routes import checks_bp
     from app.dashboard.routes import dash_bp
@@ -67,6 +68,7 @@ def create_app():
     csrf.exempt(users_bp)
     csrf.exempt(events_bp)
     csrf.exempt(companies_bp)
+    csrf.exempt(categories_bp)
     csrf.exempt(checks_bp)
     
     app.register_blueprint(auth_bp)
@@ -76,6 +78,7 @@ def create_app():
     app.register_blueprint(users_bp)
     app.register_blueprint(companies_bp, url_prefix='/companies')
     app.register_blueprint(checks_bp, url_prefix='/checks')
+    app.register_blueprint(categories_bp)
     app.register_blueprint(main_bp)
 
     # Create tables

--- a/app/categories.py
+++ b/app/categories.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+from flask_login import login_required, current_user
+from app.extensions import db
+from app.models import Category
+
+categories_bp = Blueprint('categories', __name__, url_prefix='/categories')
+
+@categories_bp.route('/create', methods=['GET', 'POST'])
+@login_required
+def create_category():
+    if current_user.role not in ('admin', 'company'):
+        abort(403)
+    if request.method == 'POST':
+        name = request.form['name']
+        if name:
+            cat = Category(name=name)
+            db.session.add(cat)
+            db.session.commit()
+            flash('Category created', 'success')
+            return redirect(url_for('categories.create_category'))
+    return render_template('create_category.html')

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2,7 +2,7 @@
 from flask import Blueprint, render_template, request, jsonify, session, flash, redirect, url_for, current_app, abort
 from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
-from app.models import Event, RSVP, Company, User, Reward
+from app.models import Event, RSVP, Company, User, Reward, Category
 from sqlalchemy import or_
 from app.auth.decorators import decode_token
 from app.extensions import db
@@ -38,6 +38,17 @@ def db_health():
 def show_events():
     events = Event.query.order_by(Event.date).all()
     return render_template('events.html', events=events)
+
+
+@main_bp.route('/events')
+def list_events():
+    category_id = request.args.get('category_id', type=int)
+    if category_id:
+        events = Event.query.filter_by(category_id=category_id).order_by(Event.date).all()
+    else:
+        events = Event.query.order_by(Event.date).all()
+    all_categories = Category.query.order_by(Category.name).all()
+    return render_template('event_list.html', events=events, all_categories=all_categories)
 
 
 @main_bp.route('/events/<event_id>')
@@ -83,7 +94,8 @@ def testing_opportunities():
 
 @main_bp.route('/create-event', methods=['GET'])
 def create_event_page():
-    return render_template('create_event.html')
+    categories = Category.query.order_by(Category.name).all()
+    return render_template('create_event.html', categories=categories)
 
 @main_bp.route('/test-sendgrid', methods=['GET'])
 def test_sendgrid():
@@ -118,6 +130,7 @@ def create_event():
     title = request.form.get('title')
     description = request.form.get('description')
     date = request.form.get('date')
+    category_id_val = request.form.get('category_id')
 
     # Validation
     if not title or not description or not date:
@@ -138,6 +151,11 @@ def create_event():
         date=event_date,
         company_id=current_user.company_id
     )
+    if category_id_val:
+        try:
+            new_event.category_id = int(category_id_val)
+        except ValueError:
+            pass
 
     image_file = request.files.get('image')
     if image_file and image_file.filename:
@@ -165,6 +183,7 @@ def edit_event(event_id):
     event = Event.query.get_or_404(event_id)
     if not current_user.company_id or event.company_id != current_user.company_id:
         return abort(403)
+    categories = Category.query.order_by(Category.name).all()
 
     if request.method == 'POST':
         title = request.form.get('title')
@@ -183,6 +202,12 @@ def edit_event(event_id):
 
         event.title = title
         event.description = description
+        category_id_val = request.form.get('category_id')
+        if category_id_val:
+            try:
+                event.category_id = int(category_id_val)
+            except ValueError:
+                pass
 
         image_file = request.files.get('image')
         if image_file and image_file.filename:
@@ -201,7 +226,7 @@ def edit_event(event_id):
             db.session.rollback()
             flash('Failed to update event. Please try again.', 'danger')
 
-    return render_template('edit_event.html', event=event)
+    return render_template('edit_event.html', event=event, categories=categories)
 
 @main_bp.route('/my-rsvps-page')
 def show_my_rsvps():

--- a/app/models.py
+++ b/app/models.py
@@ -106,6 +106,14 @@ class Company(db.Model):
         return f'<Company {self.name}>'
 
 
+class Category(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+
+    def __repr__(self):
+        return f'<Category {self.name}>'
+
+
 class Event(db.Model):
     __tablename__ = "events"
     id = db.Column(db.String, primary_key=True, default=lambda: str(uuid.uuid4()))
@@ -114,6 +122,8 @@ class Event(db.Model):
     date = db.Column(db.DateTime, nullable=False)
     company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True)
     user_id = db.Column(db.String, db.ForeignKey("users.id"), nullable=True)  # For user-created events
+    category_id = db.Column(db.Integer, db.ForeignKey('category.id'), nullable=True)
+    category = db.relationship('Category', backref='events')
     # Use dynamic loading so we can call ``event.rsvps.count()`` without
     # loading all related rows into memory.
     rsvps = db.relationship(

--- a/templates/create_category.html
+++ b/templates/create_category.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Create Category{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <div class="mb-3">
+        <label for="name" class="form-label">Category Name</label>
+        <input type="text" class="form-control" id="name" name="name" required>
+      </div>
+      <button type="submit" class="btn btn-primary">Create</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/create_event.html
+++ b/templates/create_event.html
@@ -25,6 +25,15 @@
             <label for="date" class="form-label">Event Date & Time</label>
             <input type="datetime-local" class="form-control" id="date" name="date" required>
           </div>
+          <div class="mb-3">
+            <label for="category_id" class="form-label">Category</label>
+            <select name="category_id" class="form-select">
+              <option value="">Uncategorized</option>
+              {% for cat in categories %}
+                <option value="{{ cat.id }}" {% if event and event.category_id == cat.id %}selected{% endif %}>{{ cat.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
           {% if current_user.company_id %}
           <div class="mb-3">
             <label for="image" class="form-label">Event Image</label>

--- a/templates/edit_event.html
+++ b/templates/edit_event.html
@@ -24,6 +24,15 @@
             <label for="date" class="form-label">Event Date & Time</label>
             <input type="datetime-local" class="form-control" id="date" name="date" value="{{ event.date.strftime('%Y-%m-%dT%H:%M') }}" required>
           </div>
+          <div class="mb-3">
+            <label for="category_id" class="form-label">Category</label>
+            <select name="category_id" class="form-select">
+              <option value="">Uncategorized</option>
+              {% for cat in categories %}
+                <option value="{{ cat.id }}" {% if event and event.category_id == cat.id %}selected{% endif %}>{{ cat.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
           {% if current_user.company_id %}
           <div class="mb-3">
             <label for="image" class="form-label">Event Image</label>

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -5,6 +5,9 @@
 {% block content %}
 <div class="container my-5">
   <h1>{{ event.title }}</h1>
+  {% if event.category %}
+  <p><strong>Category:</strong> {{ event.category.name }}</p>
+  {% endif %}
   <p>{{ event.description }}</p>
   <p>Date: {{ event.date }}</p>
   <p>RSVPs: {{ count }}</p>

--- a/templates/event_list.html
+++ b/templates/event_list.html
@@ -6,6 +6,17 @@
 </head>
 <body>
   <h1>Available Events</h1>
+  <form method="get" action="{{ url_for('main.list_events') }}" class="mb-4">
+    <div class="input-group">
+      <select name="category_id" class="form-select">
+        <option value="">All Categories</option>
+        {% for cat in all_categories %}
+          <option value="{{ cat.id }}" {% if request.args.get('category_id')|int == cat.id %}selected{% endif %}>{{ cat.name }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="btn btn-primary">Filter</button>
+    </div>
+  </form>
   <ul>
     {% for e in events %}
       <li>{{e.name}} on {{e.date}} — <a href="/events/{{e.id}}">Details</a>

--- a/tests/test_event_categories.py
+++ b/tests/test_event_categories.py
@@ -1,0 +1,42 @@
+import pytest
+from datetime import datetime
+from app import create_app, db
+from app.models import Event, Category
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+    return app.test_client()
+
+
+def test_filter_by_category(client):
+    with client.application.app_context():
+        music = Category(name='Music')
+        tech = Category(name='Tech')
+        db.session.add_all([music, tech])
+        db.session.commit()
+        e1 = Event(id='m1', title='Music Fest', description='A', date=datetime(2030,1,1), category_id=music.id)
+        e2 = Event(id='t1', title='Tech Conf', description='B', date=datetime(2030,1,2), category_id=tech.id)
+        db.session.add_all([e1, e2])
+        db.session.commit()
+        url = f'/events?category_id={music.id}'
+    res = client.get(url)
+    assert b'Music Fest' in res.data
+    assert b'Tech Conf' not in res.data
+
+
+def test_uncategorized_events_show(client):
+    with client.application.app_context():
+        cat = Category(name='Tech')
+        db.session.add(cat)
+        db.session.commit()
+        e1 = Event(id='u1', title='Uncat', description='A', date=datetime(2030,1,3))
+        e2 = Event(id='c1', title='Categorized', description='B', date=datetime(2030,1,4), category_id=cat.id)
+        db.session.add_all([e1, e2])
+        db.session.commit()
+    res = client.get('/events')
+    html = res.data.decode('utf-8')
+    assert 'Uncat' in html and 'Categorized' in html


### PR DESCRIPTION
## Summary
- add Category model and link to Event
- create categories blueprint and register with app factory
- allow category selection when creating or editing events
- filter events list by category
- show event category on detail page
- create simple template for adding categories
- add tests for event category filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684364b2378c832ea0a3083fc315ce23