### PR TITLE
Implement event waitlist

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,3 +29,5 @@ def export_attendees(event_id):
         mimetype='text/csv',
         headers={'Content-Disposition': f'attachment;filename=attendees_event_{event_id}.csv'}
     )
+
+

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -4,9 +4,10 @@ from flask_login import login_required, current_user
 import io
 import csv
 from werkzeug.utils import secure_filename
-from app.models import Event, RSVP, Company, User, Reward, Category, Review
+from app.models import Event, RSVP, Company, User, Reward, Category, Review, Waitlist
 from sqlalchemy import or_, func
 from app.reviews.forms import ReviewForm
+from app.users.forms import WaitlistForm
 from app.auth.decorators import decode_token
 from app.extensions import db
 import datetime
@@ -60,6 +61,7 @@ def event_detail(event_id):
     """Display a single event's details and handle reviews."""
     event = Event.query.get_or_404(event_id)
     form = ReviewForm()
+    waitlist_form = WaitlistForm()
 
     if form.validate_on_submit() and current_user.is_authenticated:
         rsvp = db.session.query(func.count()).select_from(Review).filter_by(user_id=current_user.id, event_id=event.id).scalar()
@@ -86,6 +88,8 @@ def event_detail(event_id):
         count=count,
         attendees=attendees,
         form=form,
+        waitlist_form=waitlist_form,
+        Waitlist=Waitlist,
         avg_rating=round(avg_rating, 1),
         reviews=reviews,
     )
@@ -458,6 +462,26 @@ def fulfill_rsvp(rsvp_id):
     except Exception as e:
         db.session.rollback()
         return jsonify({'error': f'Failed to update RSVP: {str(e)}'}), 500
+
+
+@main_bp.route('/events/<int:event_id>/rsvp', methods=['POST'])
+@login_required
+def rsvp_event(event_id):
+    event = Event.query.get_or_404(event_id)
+    if RSVP.query.filter_by(event_id=event.id, user_id=current_user.id).first():
+        flash('You have already RSVP\'d for this event.', 'warning')
+        return redirect(url_for('main.show_events'))
+    if event.capacity is not None and event.rsvps.count() >= event.capacity:
+        wait = Waitlist(user_id=current_user.id, event_id=event.id)
+        db.session.add(wait)
+        db.session.commit()
+        flash('Event is full. You have been added to the waitlist.', 'info')
+        return redirect(url_for('main.show_events'))
+    rsvp = RSVP(user_id=current_user.id, event_id=event.id)
+    db.session.add(rsvp)
+    db.session.commit()
+    flash('RSVP successful!', 'success')
+    return redirect(url_for('main.show_events'))
 
 
 @main_bp.route('/companies/<int:company_id>')

--- a/app/models.py
+++ b/app/models.py
@@ -127,6 +127,8 @@ class Event(db.Model):
     # Use dynamic loading so we can call ``event.rsvps.count()`` without
     # loading all related rows into memory.
     rsvps = db.relationship('RSVP', backref='event', lazy='dynamic')
+    capacity = db.Column(db.Integer, nullable=True)
+    waitlist = db.relationship('Waitlist', backref='event', lazy='dynamic')
 
     # Backwards compatibility for code that still references ``name``
     @property
@@ -160,6 +162,14 @@ class RSVP(db.Model):
     
     # Add relationships
     user = db.relationship("User", back_populates="rsvps")
+
+
+class Waitlist(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    event_id = db.Column(db.Integer, db.ForeignKey('events.id'), nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+    user = db.relationship('User', backref='waitlist_entries')
 
 
 class GiftCard(db.Model):

--- a/app/users/__init__.py
+++ b/app/users/__init__.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
 import os, uuid
 from app.extensions import db
-from app.models import User, RSVP, Event
+from app.models import User, RSVP, Event, Waitlist
 from app.users.forms import ProfileForm, CancelRSVPForm
 
 users_bp = Blueprint('users', __name__)
@@ -42,8 +42,9 @@ def my_rsvps():
     user = current_user
     rsvps = RSVP.query.filter_by(user_id=user.id).all()
     events = [rsvp.event for rsvp in rsvps if rsvp.event]
+    waitlists = Waitlist.query.filter_by(user_id=user.id).order_by(Waitlist.created_at).all()
     form = CancelRSVPForm()
-    return render_template('my_rsvps.html', events=events, form=form)
+    return render_template('my_rsvps.html', events=events, waitlists=waitlists, form=form, Waitlist=Waitlist)
 
 
 @users_bp.route('/cancel-rsvp/<int:event_id>', methods=['POST'])
@@ -53,6 +54,11 @@ def cancel_rsvp(event_id: int):
     rsvp = RSVP.query.filter_by(user_id=current_user.id, event_id=str(event_id)).first()
     if rsvp:
         db.session.delete(rsvp)
+        next_wait = Waitlist.query.filter_by(event_id=str(event_id)).order_by(Waitlist.created_at).first()
+        if next_wait:
+            new_rsvp = RSVP(user_id=next_wait.user_id, event_id=str(event_id))
+            db.session.delete(next_wait)
+            db.session.add(new_rsvp)
         db.session.commit()
         flash('RSVP cancelled.', 'success')
     return redirect(url_for('users.my_rsvps'))

--- a/app/users/forms.py
+++ b/app/users/forms.py
@@ -13,3 +13,7 @@ class ProfileForm(FlaskForm):
 class CancelRSVPForm(FlaskForm):
     """Empty form used solely for CSRF protection when cancelling an RSVP."""
     submit = SubmitField('Cancel RSVP')
+
+
+class WaitlistForm(FlaskForm):
+    pass

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -18,6 +18,9 @@
 {% endif %}
 
 <p><strong>RSVPs:</strong> {{ count }}</p>
+{% if event.capacity %}
+  <p>Seats left: {{ event.capacity - event.rsvps.count() }}</p>
+{% endif %}
 
 {% if event.category %}
   <p><strong>Category:</strong> {{ event.category.name }}</p>
@@ -35,6 +38,27 @@
     </ul>
   {% else %}
     <p>No one has RSVP’d yet.</p>
+  {% endif %}
+
+  {% if current_user.is_authenticated %}
+    {% set user_rsvp = event.rsvps.filter_by(user_id=current_user.id).first() %}
+    {% set waitlisted = event.waitlist.filter_by(user_id=current_user.id).first() %}
+    {% if not user_rsvp %}
+      {% if event.capacity and event.rsvps.count() >= event.capacity %}
+        <form method="post" action="{{ url_for('main.rsvp_event', event_id=event.id) }}">
+          {{ waitlist_form.csrf_token }}
+          <button type="submit" class="btn btn-secondary">Join Waitlist</button>
+        </form>
+        {% if waitlisted %}
+          <p>You’re #{{ event.waitlist.filter(Waitlist.user_id == current_user.id).order_by(Waitlist.created_at).count() }} on the waitlist.</p>
+        {% endif %}
+      {% else %}
+        <form method="post" action="{{ url_for('main.rsvp_event', event_id=event.id) }}">
+          {{ waitlist_form.csrf_token }}
+          <button type="submit" class="btn btn-primary">RSVP</button>
+        </form>
+      {% endif %}
+    {% endif %}
   {% endif %}
 
   <p><strong>Average Rating:</strong> {{ avg_rating }} / 5</p>

--- a/templates/my_rsvps.html
+++ b/templates/my_rsvps.html
@@ -4,8 +4,9 @@
 
 {% block content %}
   <h2 class="mb-4">My RSVP'd Events</h2>
+  <h3>Confirmed RSVPs</h3>
   {% if events %}
-    <ul class="list-group">
+    <ul class="list-group mb-4">
       {% for event in events %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <div>
@@ -21,6 +22,19 @@
     </ul>
   {% else %}
     <p>You haven’t signed up for any events yet.</p>
+  {% endif %}
+
+  <h3>Waitlisted</h3>
+  {% if waitlists %}
+    <ul class="list-group">
+      {% for wl in waitlists %}
+        <li class="list-group-item">
+          {{ wl.event.title }} - #{{ wl.event.waitlist.filter(Waitlist.created_at <= wl.created_at).count() }}
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>No waitlisted events.</p>
   {% endif %}
 {% endblock %}
 

--- a/tests/test_waitlist.py
+++ b/tests/test_waitlist.py
@@ -1,0 +1,57 @@
+import pytest
+from datetime import datetime
+from app import create_app, db
+from app.models import User, Event, RSVP, Waitlist
+
+@pytest.fixture
+def client(tmp_path):
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+    return app.test_client()
+
+
+def login(client, email, password):
+    client.post('/login', data={'email': email, 'password': password})
+
+
+def logout(client):
+    client.post('/auth/logout')
+
+
+def test_waitlist_promotion(client):
+    with client.application.app_context():
+        user1 = User(email='wl1@example.com', password='pw')
+        user2 = User(email='wl2@example.com', password='pw')
+        event = Event(id='50', title='Cap Event', description='Desc', date=datetime(2030,1,1), capacity=1)
+        db.session.add_all([user1, user2, event])
+        db.session.commit()
+        evt_id = event.id
+
+    login(client, 'wl1@example.com', 'pw')
+    res = client.post(f'/events/{evt_id}/rsvp', follow_redirects=True)
+    assert b'RSVP successful' in res.data
+    with client.application.app_context():
+        assert RSVP.query.count() == 1
+        assert Waitlist.query.count() == 0
+
+    logout(client)
+    login(client, 'wl2@example.com', 'pw')
+    res = client.post(f'/events/{evt_id}/rsvp', follow_redirects=True)
+    assert b'added to the waitlist' in res.data
+    with client.application.app_context():
+        assert RSVP.query.count() == 1
+        assert Waitlist.query.count() == 1
+
+    logout(client)
+    login(client, 'wl1@example.com', 'pw')
+    res = client.post(f'/cancel-rsvp/{int(evt_id)}', follow_redirects=True)
+    assert b'RSVP cancelled.' in res.data
+    with client.application.app_context():
+        assert RSVP.query.count() == 1
+        assert Waitlist.query.count() == 0
+        rsvp = RSVP.query.first()
+        user = User.query.get(rsvp.user_id)
+        assert user.email == 'wl2@example.com'


### PR DESCRIPTION
## Summary
- support capacity limits and waitlists on events
- add minimal WaitlistForm
- handle waitlist logic when RSVPing and cancelling
- display seat counts, waitlist position and new sections on profile pages
- test waitlist promotion flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ce0721a8832eb80e7acdf7800059