### PR TITLE
Implement paginated event listing

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -49,13 +49,16 @@ def show_events():
 
 @main_bp.route('/events')
 def list_events():
+    page = request.args.get('page', 1, type=int)
     category_id = request.args.get('category_id', type=int)
+    query = Event.query
     if category_id:
-        events = Event.query.filter_by(category_id=category_id).order_by(Event.date).all()
-    else:
-        events = Event.query.order_by(Event.date).all()
+        query = query.filter_by(category_id=category_id)
+    pagination = query.order_by(Event.date).paginate(page=page, per_page=10, error_out=False)
+    events = pagination.items
     all_categories = Category.query.order_by(Category.name).all()
-    return render_template('event_list.html', events=events, all_categories=all_categories)
+    counts = {e.id: e.rsvps.count() for e in events}
+    return render_template('events.html', events=events, pagination=pagination, counts=counts, all_categories=all_categories)
 
 
 @main_bp.route('/events/<event_id>', methods=['GET', 'POST'])

--- a/templates/events.html
+++ b/templates/events.html
@@ -127,7 +127,7 @@
             </div>
           </div>
           {% else %}
-          <a href="{{ url_for('auth.login_page') }}" class="btn btn-outline-primary w-100">
+          <a href="{{ url_for('auth.login') }}" class="btn btn-outline-primary w-100">
             <i class="bi bi-box-arrow-in-right me-2"></i>Login to Register
           </a>
           {% endif %}
@@ -153,6 +153,24 @@
     </div>
   </div>
   {% endif %}
+  <nav aria-label="Event pagination">
+    <ul class="pagination">
+      {% if pagination.has_prev %}
+        <li class="page-item">
+          <a class="page-link" href="{{ url_for('main.list_events', page=pagination.prev_num) }}">Previous</a>
+        </li>
+      {% else %}
+        <li class="page-item disabled"><span class="page-link">Previous</span></li>
+      {% endif %}
+      {% if pagination.has_next %}
+        <li class="page-item">
+          <a class="page-link" href="{{ url_for('main.list_events', page=pagination.next_num) }}">Next</a>
+        </li>
+      {% else %}
+        <li class="page-item disabled"><span class="page-link">Next</span></li>
+      {% endif %}
+    </ul>
+  </nav>
 </div>
 
 <style>

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,45 @@
+import re
+import pytest
+from datetime import datetime
+from app import create_app, db
+from app.models import Event
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        for i in range(1, 26):
+            evt = Event(id=str(i), title=f'Event {i}', description='D', date=datetime(2030, 1, i))
+            db.session.add(evt)
+        db.session.commit()
+    return app.test_client()
+
+
+def extract_titles(html: str):
+    return re.findall(r'<h5 class="card-title[^>]*>([^<]+)</h5>', html)
+
+
+def test_first_page_shows_ten_events(client):
+    res = client.get('/events?page=1')
+    assert res.status_code == 200
+    titles = extract_titles(res.get_data(as_text=True))
+    assert len(titles) == 10
+    assert 'Event 1' in titles and 'Event 10' in titles
+
+
+def test_third_page_shows_remaining_events(client):
+    res = client.get('/events?page=3')
+    html = res.get_data(as_text=True)
+    titles = extract_titles(html)
+    assert len(titles) == 5
+    assert 'Event 25' in titles
+    assert '/events?page=2' in html  # Previous enabled
+
+
+def test_out_of_range_page_returns_empty(client):
+    res = client.get('/events?page=999')
+    titles = extract_titles(res.get_data(as_text=True))
+    assert res.status_code == 200
+    assert titles == []


### PR DESCRIPTION
## Summary
- add pagination logic to `/events` route
- display pagination controls in events template
- create tests for event pagination

## Testing
- `pytest tests/test_pagination.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68447e4ff00c832e9318c522f7ce3032