### PR TITLE
Fix registration form

### DIFF
--- a/templates/register.html
+++ b/templates/register.html
@@ -27,7 +27,7 @@
           {% endif %}
         {% endwith %}
 
-        <form method="post" action="/register" novalidate class="needs-validation" id="registerForm" enctype="multipart/form-data">
+        <form method="post" action="{{ url_for('api_users.register') }}" novalidate class="needs-validation" id="registerForm" enctype="multipart/form-data">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <!-- Personal Information Section -->
           <div class="mb-4">
@@ -368,13 +368,52 @@ function previewImage(input) {
     
     confirmPassword.addEventListener('input', validatePasswords);
 
-    form.addEventListener('submit', function(event) {
+    form.addEventListener('submit', async function(event) {
+      event.preventDefault();
+
       validatePasswordStrength();
       validatePasswords();
       if (form.checkValidity() === false) {
-        event.preventDefault();
         event.stopPropagation();
+        form.classList.add('was-validated');
+        return;
       }
+
+      const formData = new FormData(form);
+      const payload = {
+        firstName: formData.get('firstName'),
+        lastName: formData.get('lastName'),
+        email: formData.get('email'),
+        phone: formData.get('phone'),
+        disabilities: formData.getAll('disabilities'),
+        specificDisability: formData.get('specificDisability'),
+        assistiveTech: formData.get('assistiveTech'),
+        techExperience: formData.get('techExperience'),
+        interests: formData.getAll('interests'),
+        password: formData.get('password'),
+        emailNotifications: formData.get('emailNotifications') === 'true',
+        newsletter: formData.get('newsletter') === 'true',
+        terms: formData.get('terms') !== null
+      };
+
+      try {
+        const res = await fetch(form.action, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json();
+
+        if (res.ok) {
+          alert('Registered! Please log in.');
+          window.location.href = '{{ url_for('auth.login') }}';
+        } else {
+          alert('Error: ' + (data.error || 'Registration failed'));
+        }
+      } catch (error) {
+        alert('Error: Unable to connect to server');
+      }
+
       form.classList.add('was-validated');
     }, false);
   }, false);

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -133,3 +133,29 @@ def test_update_profile_avatar_save_failure(mock_save, client):
         # Re-fetch user after POST, because the session might have changed the object
         user_after_post = User.query.filter_by(email='test@example.com').first()
         assert user_after_post.avatar_filename == original_avatar # Should not have changed
+
+
+def test_registration_page_load(client):
+    with client.application.app_context():
+        response = client.get(url_for('api_users.show_register'))
+    assert response.status_code == 200
+    assert b'Join Tech Access' in response.data
+
+
+def test_register_user_via_form(client):
+    with client.application.app_context():
+        target_url = url_for('api_users.register')
+    form_data = {
+        'firstName': 'Jane',
+        'lastName': 'Doe',
+        'email': 'jane@example.com',
+        'password': 'Password123!',
+        'techExperience': 'beginner',
+        'terms': 'true'
+    }
+    response = client.post(target_url, data=form_data, follow_redirects=False)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['message'] == 'User registered successfully'
+    with client.application.app_context():
+        assert User.query.filter_by(email='jane@example.com').first() is not None


### PR DESCRIPTION
## Summary
- validate full registration data by using `RegistrationSchema`
- let API register route accept JSON or form data
- send registration JSON via fetch from template
- update registration tests for form submission

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b42575f90832e9381d418b872644c