### PR TITLE
Fix: Auto-login and redirect users after registration

### DIFF
--- a/templates/register.html
+++ b/templates/register.html
@@ -405,8 +405,8 @@ function previewImage(input) {
         const data = await res.json();
 
         if (res.ok) {
-          alert('Registered! Please log in.');
-          window.location.href = '{{ url_for('auth.login') }}';
+          // Server will handle redirect, client-side redirect removed.
+          // console.log("Registration successful, server will redirect.");
         } else {
           alert('Error: ' + (data.error || 'Registration failed'));
         }

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -145,8 +145,8 @@
         const data = await res.json();
         
         if (res.ok) {
-          alert('Registered! Please log in.');
-          window.location.href = '/login';
+          // Server will handle redirect, client-side redirect removed.
+          // console.log("Registration successful, server will redirect.");
         } else {
           alert('Error: ' + (data.msg || data.error));
         }


### PR DESCRIPTION
This commit addresses an issue where you were not automatically redirected to your dashboard after creating an account. Instead, you were sent to the login page.

Changes include:

1.  Modified `/auth/register` (from `app/auth/routes.py`):
    - You are now logged in automatically using `login_user()` after successful registration.
    - Session variables (email, role, company_id if applicable, token) are set.
    - For 'company' role signups, a corresponding Company record is created with `approved=False`.
    - You are redirected to `dashboard.member_dashboard` or `dashboard.company_dashboard` based on your role.

2.  Modified `/api/users/register` (from `app/users/routes.py`):
    - For form submissions, you are now logged in automatically.
    - Session variables (email, role, token) are set.
    - You are redirected to `dashboard.member_dashboard`.
    - JSON API requests to this endpoint still return a token and user details as before, without redirect.

3.  Client-Side JavaScript Updated:
    - Removed client-side redirection logic from `templates/register.html` and `templates/signup.html` as the server now handles redirects.

4.  Tests Added:
    - New test cases in `tests/test_users.py` verify: - Correct redirection to dashboards after registration via both routes. - Proper session variables (role, email, token, company_id) being set. - Creation of User and Company (for company signups) objects in the database.

This change improves your experience by providing a smoother onboarding flow after account creation.