### PR TITLE
Add search filtering for events list

### DIFF
--- a/app/users/routes.py
+++ b/app/users/routes.py
@@ -50,10 +50,12 @@ def register():
 
     if is_json_request:
         data = request.get_json()
+        if not data:
+            return jsonify({'error': 'No JSON data provided'}), 400
     else: # Form submission
         form = request.form
-        if not form: # Should not happen if not JSON and POST
-            return jsonify({'error': 'No form data provided'}), 400
+        if not form:
+            return jsonify({'error': 'No JSON data provided'}), 400
         data = form.to_dict(flat=True)
         # Handling list fields from form
         data['disabilities'] = form.getlist('disabilities')

--- a/templates/events.html
+++ b/templates/events.html
@@ -3,11 +3,19 @@
 {% block title %}Events – Tech Access{% endblock %}
 
 {% block content %}
+<style>
+  #event-search {
+    max-width: 400px;
+    margin-bottom: 1rem;
+  }
+</style>
+
 <h2>Upcoming Events</h2>
+<input type="text" id="event-search" class="form-control" placeholder="Search events...">
 {% if upcoming_events %}
-  <ul class="list-group mb-4">
+  <ul id="upcoming-events" class="list-group mb-4">
     {% for ev in upcoming_events %}
-      <li class="list-group-item">
+      <li class="list-group-item" data-description="{{ ev.description }}">
         <a href="{{ url_for('main.event_detail', event_id=ev.id) }}">{{ ev.title }}</a> — {{ ev.date }}
       </li>
     {% endfor %}
@@ -18,14 +26,30 @@
 
 <h2>Past Events</h2>
 {% if past_events %}
-  <ul class="list-group">
+  <ul id="past-events" class="list-group">
     {% for ev in past_events %}
-      <li class="list-group-item text-muted">
+      <li class="list-group-item text-muted" data-description="{{ ev.description }}">
         <a href="{{ url_for('main.event_detail', event_id=ev.id) }}">{{ ev.title }}</a> — {{ ev.date }}
       </li>
     {% endfor %}
   </ul>
-{% else %}
-  <p>No past events.</p>
-{% endif %}
+  {% else %}
+    <p>No past events.</p>
+  {% endif %}
+
+  <script>
+    const searchInput = document.getElementById('event-search');
+    searchInput.addEventListener('input', function() {
+      const term = this.value.toLowerCase();
+      document.querySelectorAll('#upcoming-events li, #past-events li').forEach(li => {
+        const text = li.textContent.toLowerCase();
+        const desc = (li.dataset.description || '').toLowerCase();
+        if (text.includes(term) || desc.includes(term)) {
+          li.style.display = '';
+        } else {
+          li.style.display = 'none';
+        }
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a search box to events.html and client-side JS filtering logic
- style the search input
- return consistent JSON error for empty registration request

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684df04db548832e919df76942793dab