### PR TITLE
Fix tests for updated events page

### DIFF
--- a/test_users.py
+++ b/test_users.py
@@ -150,10 +150,10 @@ class TestUserRegistration:
     def test_register_no_json_data(self, client):
         """Test registration without JSON data."""
         response = client.post('/api/users/register')
-        
+
         assert response.status_code == 400
         data = json.loads(response.data)
-        assert data['error'] == 'No JSON data provided'
+        assert data['error'] == 'No form data provided'
 
 class TestUserLogin:
     """Test cases for user login endpoint."""

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -179,3 +179,12 @@ def test_home_page_loads_with_data(client):
         db.session.delete(company2)
         db.session.delete(company3)
         db.session.commit()
+
+
+def test_events_page_has_search_box(client):
+    with client.application.app_context():
+        response = client.get(url_for('main.list_events'))
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert '<input' in html and 'id="event-search"' in html

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -18,7 +18,8 @@ def client():
 
 
 def extract_titles(html: str):
-    return re.findall(r'<li class="list-group-item(?: text-muted)?">\s*<a [^>]+>([^<]+)</a>', html)
+    """Return all event titles from the events list markup."""
+    return re.findall(r'<li class="list-group-item(?: text-muted)?(?: event-item)?"[^>]*>\s*<a [^>]+>([^<]+)</a>', html)
 
 
 def test_all_events_displayed(client):


### PR DESCRIPTION
## Summary
- adjust pagination test to handle new event-item markup
- change registration expectations for form-based endpoints
- ensure redirects are checked within app context
- test presence of new event search box on /events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfba1fe50832e883dfd6466edb917