### PR TITLE
Add step to remove old SQLite DB before migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Remove existing SQLite DB
+        run: rm -f app.db
+
       - name: Run database migrations
         run: flask db upgrade
 


### PR DESCRIPTION
## Summary
- remove `app.db` in CI before running migrations to ensure a clean SQLite database

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 19 failed, 160 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68542e6efc48832e970a1a243a12486b