### PR TITLE
Attempt to fix Jinja2 pagination macro and address test failures

### DIFF
--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -1,8 +1,8 @@
-{% macro render_pagination(pagination, endpoint, **kwargs) %}
+{% macro render_pagination(pagination, endpoint, query_params={}) %}
   <nav aria-label="Page navigation">
     <ul class="pagination justify-content-center">
       {% if pagination.has_prev %}
-        <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, page=pagination.prev_num, **kwargs) }}">Previous</a></li>
+        <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, page=pagination.prev_num, **query_params) }}">Previous</a></li>
       {% else %}
         <li class="page-item disabled"><span class="page-link">Previous</span></li>
       {% endif %}
@@ -12,7 +12,7 @@
           {% if p == pagination.page %}
             <li class="page-item active"><span class="page-link">{{ p }}</span></li>
           {% else %}
-            <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, page=p, **kwargs) }}">{{ p }}</a></li>
+            <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, page=p, **query_params) }}">{{ p }}</a></li>
           {% endif %}
         {% else %}
           <li class="page-item disabled"><span class="page-link">...</span></li>
@@ -20,7 +20,7 @@
       {% endfor %}
 
       {% if pagination.has_next %}
-        <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, page=pagination.next_num, **kwargs) }}">Next</a></li>
+        <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, page=pagination.next_num, **query_params) }}">Next</a></li>
       {% else %}
         <li class="page-item disabled"><span class="page-link">Next</span></li>
       {% endif %}

--- a/templates/events.html
+++ b/templates/events.html
@@ -17,7 +17,11 @@
     {% endfor %}
   </ul>
   {% if upcoming_events_pagination.pages > 1 %}
-    {{ macros.render_pagination(upcoming_events_pagination, 'main.list_events') }}
+    {% set query_params = {} %}
+    {% if request.args.get('query') %}
+      {% set _ = query_params.update({'query': request.args.get('query')}) %}
+    {% endif %}
+    {{ macros.render_pagination(upcoming_events_pagination, 'main.list_events', query_params=query_params) }}
   {% endif %}
 {% else %}
   <p>No upcoming events.</p>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,11 +33,16 @@ def test_client(app):
 def init_database(app): # Depends on the app fixture to get app.app_context()
     """Fixture to initialize the database for each test function."""
     with app.app_context():
-        db.drop_all() # Drop all tables
-        db.create_all() # Create all tables
-        yield db         # Provide the db object to the test if needed
-        db.session.remove() # Clean up session
-        # db.drop_all() # Optional: drop tables again after test, if desired
+        # Setup: drop and recreate all tables
+        db.drop_all()
+        db.create_all()
+
+        # Yield the db instance for use in tests
+        yield db
+
+        # Teardown: remove session and drop all tables to ensure clean state for next test
+        db.session.remove()
+        db.drop_all()
 
 @pytest.fixture
 def test_user(init_database): # Depends on init_database to ensure clean db


### PR DESCRIPTION
This commit includes several attempts to fix a persistent `jinja2.exceptions.TemplateSyntaxError: expected token 'name', got '**'` related to the `render_pagination` macro in `templates/_macros.html`.

Steps taken:
1.  Initial exploration: Identified project structure (Flask app), dependencies (Poetry), and test suite (pytest).
2.  Ran tests: Encountered 55 initial failures, largely due to the Jinja2 TemplateSyntaxError.
3.  Attempted various fixes for the Jinja2 macro in `templates/_macros.html`:
    *   Changed `**kwargs` to `extra_args={}` in macro definition and `**extra_args` in `url_for` calls.
    *   Changed macro call in `templates/events.html` to explicitly build a `query_params` dictionary and pass it.
    *   Reverted macro definition to `**kwargs` as per documentation, but the error persisted, suggesting the issue might be in the call or environment.
    *   The core issue seems to be how arbitrary keyword arguments are defined in a macro and then unpacked into `url_for`.
4.  Investigated SQLAlchemy `DetachedInstanceError` and `AttributeError` in `tests/test_categories.py`:
    *   Modified `sample_categories` fixture to return Category objects instead of IDs, which led to `DetachedInstanceError`.
    *   Reverted `sample_categories` to return IDs.
    *   Updated `sample_events` fixture to fetch categories using IDs to prevent `AttributeError` during its setup.
    *   Updated several test functions in `test_categories.py` to fetch Category objects using IDs from `sample_categories` to prevent `AttributeError`.
    *   Modified `init_database` fixture in `tests/conftest.py` for cleaner teardown.

State of the code:
*   The `templates/_macros.html` file has the `render_pagination` macro defined as `{% macro render_pagination(pagination, endpoint, query_params={}) %}` with `**query_params` used in `url_for` calls.
*   The `templates/events.html` file calls this macro by building a `query_params` dictionary.
*   Several tests in `tests/test_categories.py` have been updated to fetch Category objects from IDs, but the `DetachedInstanceError` and related `AttributeError`s are not fully resolved, and the `test_example_fixture_usage` still fails to find an event, indicating underlying fixture or session management issues.

Reason for being stuck:
The primary unresolved issue is the `jinja2.exceptions.TemplateSyntaxError: expected token 'name', got '**'` in `templates/_macros.html`. Despite trying several documented ways to handle `kwargs` in Jinja2 macros, this syntax error persists when running most tests. This prevents the majority of tests that render UI from passing. The SQLAlchemy `DetachedInstanceError` and related `AttributeError`s in `test_categories.py` are secondary but also indicate issues with test fixture setup and database session management that couldn't be fully resolved without first fixing the blocking Jinja2 error.